### PR TITLE
Cancelable and uncancelable melee states

### DIFF
--- a/Content/CM/Abilities/Assassin/PrimaryAttack/AM_AssassinPrimaryCombo.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/AM_AssassinPrimaryCombo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab0bb42bbde97681a4a8954985c0ed79ea0a51c0ab72dfd786131c95e8a76832
-size 103453
+oid sha256:6c41eb8dea8bd36ad61b10e3f872aec2b57a454f866985d783b81f35c52db998
+size 106319

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/AM_AssassinPrimaryComboInMotion.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/AM_AssassinPrimaryComboInMotion.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:111004b28e5be02cadfb34b6403553fa1e2c4559a7c6ef23a7224eefc1ff219e
-size 103749
+oid sha256:6d4e9bd0554d912730f67011ff10b143f804366b53b966e0b946938acbf02953
+size 106321

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/Assassin_PrimaryAttack_Left.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/Assassin_PrimaryAttack_Left.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca9757d9528d2170c080b29d42f82a75b0cd3aadd58127f8385ed5b010d71f37
-size 100164

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/Assassin_PrimaryAttack_Right.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/Assassin_PrimaryAttack_Right.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c944da4684f8d8590453f484319d3f988b6d8d5405d45f11bd8bdd517bd59b89
-size 99188

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e862610bf5f55225ea2331347eb41c32a83eb89e4b616fda6a234f844ea28fb
-size 154003
+oid sha256:6dcbe72a7f815cb3e4cedcb548705aa2e267da181f73da5c415fd0d761073a75
+size 147810

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97ee59d1a1777e8ec0abbcea270e0126fb1365d39a578cf681922cdaa345f7f6
-size 112961
+oid sha256:7e862610bf5f55225ea2331347eb41c32a83eb89e4b616fda6a234f844ea28fb
+size 154003

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/GA_AssassinPrimaryAttackCombo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6dcbe72a7f815cb3e4cedcb548705aa2e267da181f73da5c415fd0d761073a75
-size 147810
+oid sha256:fb31abcc52d139c0995f12322333b307ec59e87aa2a1f326f04257d48570320f
+size 149452

--- a/Content/CM/Abilities/Assassin/PrimaryAttack/Notif_AttackComplete.uasset
+++ b/Content/CM/Abilities/Assassin/PrimaryAttack/Notif_AttackComplete.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1b27be1b1395bf29fe234baedf3a188d8bdbb55b1fac0a4697715570674f2c
+size 20082

--- a/Content/CM/Abilities/GameplayTags.csv
+++ b/Content/CM/Abilities/GameplayTags.csv
@@ -23,3 +23,4 @@ State.GCD,State.GCD,global cooldown
 State.Sprinting,State.Sprinting,Character is sprinting
 State.Walking,State.Walking,Character is walking
 Event.Montage.MeleeHit,Event.Montage.MeleeHit,Montage triggered hit
+Event.Montage.AttackComplete,Event.Montage.AttackComplete,Montage attack complete

--- a/Content/CM/Abilities/GameplayTags.uasset
+++ b/Content/CM/Abilities/GameplayTags.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2435fa8d91265f1b117ce69c14b959e8221a2b953df91b0dd77a77cef99edbc3
-size 5024
+oid sha256:f1ad68259d8f55e92f3f3487a41037c122c913c6f7518c4bb2c0d384055ffd6a
+size 5163


### PR DESCRIPTION
Closes #37 

Creates cancelable and uncancelable melee ability states

![image](https://user-images.githubusercontent.com/14217/70572635-29365300-1b6e-11ea-8a3d-d26072823a1b.png)

Implemented via notifie via following logic:
- Add dynamic triggers in montages for `Event.Montage.MeleeHit` during weapon apex  and `Event.Montage.AttackComplete` when the swing finishes
- Listen for those events in the ability
  - On melee hit, do a frontal cone trace and then apply damage to actors within
  - On attack complete, check to see if the player has released the ability input
    - If input has been released since attack started, end the ability
    - if input has not been released, continue with montage, and if montage finished, play montage again